### PR TITLE
Sms send crash fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+build/
+.idea
+.gradle
+*.iml
+gradle.properties
+local.properties
+.DS_Store
+captures/
+.externalNativeBuild
+output.json
+

--- a/TKConfig/AndroidManifest.xml
+++ b/TKConfig/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.WRITE_SMS" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
 
     <application
         android:name="ro.ciubex.tkconfig.TKConfigApplication"

--- a/TKConfig/src/ro/ciubex/tkconfig/TKConfigApplication.java
+++ b/TKConfig/src/ro/ciubex/tkconfig/TKConfigApplication.java
@@ -85,6 +85,7 @@ public class TKConfigApplication extends Application {
     public static final String PERMISSION_FOR_WRITE_SMS = "android.permission.WRITE_SMS";
     public static final String PERMISSION_FOR_READ_EXTERNAL_STORAGE = "android.permission.READ_EXTERNAL_STORAGE";
     public static final String PERMISSION_FOR_WRITE_EXTERNAL_STORAGE = "android.permission.WRITE_EXTERNAL_STORAGE";
+    public static final String PERMISSION_FOR_READ_PHONE_STATE = "android.permission.READ_PHONE_STATE";
 
     public static final String KEY_APP_THEME = "appTheme";
 
@@ -94,7 +95,8 @@ public class TKConfigApplication extends Application {
             PERMISSION_FOR_READ_SMS,
             PERMISSION_FOR_WRITE_SMS,
             PERMISSION_FOR_READ_EXTERNAL_STORAGE,
-            PERMISSION_FOR_WRITE_EXTERNAL_STORAGE
+            PERMISSION_FOR_WRITE_EXTERNAL_STORAGE,
+            PERMISSION_FOR_READ_PHONE_STATE
     );
 
     /**


### PR DESCRIPTION
READ_PHONE_STATE permission is needed to send SMS in Android 8